### PR TITLE
fix: Remove reference to cr.yaml and skip main

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -3,9 +3,11 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
+      # - main Skip on master until it's stabilized
+      - chart_tests
     paths:
       - "charts/**"
+      - ".github/**"
 
 jobs:
   release:
@@ -29,8 +31,6 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # pin@v1.5.0
-        with:
-          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "charts/**"
+      - ".github/**"
 
 jobs:
   check-readme:


### PR DESCRIPTION
This will skip the release charts workflow on main push until we set the correct versioning.